### PR TITLE
Update Quartz theme and tag styles

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -8,7 +8,7 @@ import * as Plugin from "./quartz/plugins"
  */
 const config: QuartzConfig = {
   configuration: {
-    pageTitle: "Quartz 4",
+    pageTitle: "ТАБАКОВСКИЙ",
     pageTitleSuffix: "",
     enableSPA: true,
     enablePopovers: true,

--- a/quartz/components/ArticleTitle.tsx
+++ b/quartz/components/ArticleTitle.tsx
@@ -3,16 +3,24 @@ import { classNames } from "../util/lang"
 
 const ArticleTitle: QuartzComponent = ({ fileData, displayClass }: QuartzComponentProps) => {
   const title = fileData.frontmatter?.title
-  const isIndex = fileData.slug && fileData.slug.endsWith("/index")
-  // DEBUG: выводим значения для отладки
-  console.log('DEBUG ArticleTitle:', {slug: fileData.slug, title, firstHeading: fileData.firstHeading});
-  if (title && !(isIndex && title === 'index')) {
-    return <h1 class={classNames(displayClass, "article-title")}>{title}</h1>
-  } else if (isIndex && fileData.firstHeading) {
-    return <h1 class={classNames(displayClass, "article-title")}>{fileData.firstHeading}</h1>
-  } else {
-    return null;
+  const slug = fileData.slug ?? ""
+  const isIndex = slug === "index" || slug.endsWith("/index")
+
+  if (isIndex) {
+    if (fileData.firstHeading) {
+      return <h1 class={classNames(displayClass, "article-title")}>{fileData.firstHeading}</h1>
+    } else if (title && title !== "index") {
+      return <h1 class={classNames(displayClass, "article-title")}>{title}</h1>
+    } else {
+      return null
+    }
   }
+
+  if (title) {
+    return <h1 class={classNames(displayClass, "article-title")}>{title}</h1>
+  }
+
+  return null
 }
 
 ArticleTitle.css = `

--- a/quartz/components/PageTitle.tsx
+++ b/quartz/components/PageTitle.tsx
@@ -18,6 +18,7 @@ PageTitle.css = `
   font-size: 1.75rem;
   margin: 0;
   font-family: var(--titleFont);
+  flex-shrink: 0;
 }
 `
 

--- a/quartz/components/TagList.tsx
+++ b/quartz/components/TagList.tsx
@@ -25,17 +25,19 @@ const TagList: QuartzComponent = ({ fileData, displayClass }: QuartzComponentPro
 }
 
 TagList.css = `
+
 .tags {
   list-style: none;
   display: flex;
   padding-left: 0;
-  gap: 0.4rem;
+  gap: 0.5rem;
   margin: 1rem 0;
   flex-wrap: wrap;
 }
 
 .section-li > .section > .tags {
-  justify-content: flex-end;
+  justify-content: flex-start;
+  flex-wrap: wrap;
 }
   
 .tags > li {
@@ -46,10 +48,11 @@ TagList.css = `
 }
 
 a.internal.tag-link {
-  border-radius: 8px;
+  border-radius: 12px;
   background-color: var(--highlight);
-  padding: 0.2rem 0.4rem;
-  margin: 0 0.1rem;
+  padding: 0.25rem 0.6rem;
+  margin: 0;
+  display: inline-block;
 }
 `
 

--- a/quartz/components/styles/listPage.scss
+++ b/quartz/components/styles/listPage.scss
@@ -15,7 +15,9 @@ li.section-li {
 
     @media all and ($mobile) {
       & > .tags {
-        display: none;
+        display: flex;
+        margin-top: 0.25rem;
+        flex-wrap: wrap;
       }
     }
 
@@ -35,6 +37,8 @@ li.section-li {
   grid-template-columns: fit-content(8em) 1fr !important;
 
   & > .tags {
-    display: none;
+    display: flex;
+    margin-top: 0.25rem;
+    flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
## Summary
- update site title to "ТАБАКОВСКИЙ"
- hide automatic `index` heading and prefer first markdown heading
- keep page title static in the sidebar
- round tag chips and display them in a single row
- tweak list page layout so tags show neatly on mobile

## Testing
- `npm run check` *(fails: Cannot find module type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6876cf656b9c8329975a57cbf10701c7