### PR TITLE
Improve base site UI

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -8,7 +8,7 @@ import * as Plugin from "./quartz/plugins"
  */
 const config: QuartzConfig = {
   configuration: {
-    pageTitle: "Quartz 4",
+    pageTitle: "ТАБАКОВСКИЙ",
     pageTitleSuffix: "",
     enableSPA: true,
     enablePopovers: true,

--- a/quartz/components/ArticleTitle.tsx
+++ b/quartz/components/ArticleTitle.tsx
@@ -3,10 +3,8 @@ import { classNames } from "../util/lang"
 
 const ArticleTitle: QuartzComponent = ({ fileData, displayClass }: QuartzComponentProps) => {
   const title = fileData.frontmatter?.title
-  const isIndex = fileData.slug && fileData.slug.endsWith("/index")
-  // DEBUG: выводим значения для отладки
-  console.log('DEBUG ArticleTitle:', {slug: fileData.slug, title, firstHeading: fileData.firstHeading});
-  if (title && !(isIndex && title === 'index')) {
+  const isIndex = fileData.slug === "index" || fileData.slug?.endsWith("/index")
+  if (title && title !== "index") {
     return <h1 class={classNames(displayClass, "article-title")}>{title}</h1>
   } else if (isIndex && fileData.firstHeading) {
     return <h1 class={classNames(displayClass, "article-title")}>{fileData.firstHeading}</h1>

--- a/quartz/components/PageTitle.tsx
+++ b/quartz/components/PageTitle.tsx
@@ -18,6 +18,8 @@ PageTitle.css = `
   font-size: 1.75rem;
   margin: 0;
   font-family: var(--titleFont);
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 `
 

--- a/quartz/components/TagList.tsx
+++ b/quartz/components/TagList.tsx
@@ -32,6 +32,7 @@ TagList.css = `
   gap: 0.4rem;
   margin: 1rem 0;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .section-li > .section > .tags {
@@ -46,9 +47,9 @@ TagList.css = `
 }
 
 a.internal.tag-link {
-  border-radius: 8px;
+  border-radius: 12px;
   background-color: var(--highlight);
-  padding: 0.2rem 0.4rem;
+  padding: 0.2rem 0.6rem;
   margin: 0 0.1rem;
 }
 `


### PR DESCRIPTION
## Summary
- change site title to ТАБАКОВСКИЙ
- keep the left title from shrinking
- hide automatically added `index` heading on the home page
- round tag chips and keep them inline

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876cff4f0fc8329a390313f7052626c